### PR TITLE
Fix memory leak in retrieve_image

### DIFF
--- a/InstantCameraAppSrc/CInstantCameraAppSrc.cpp
+++ b/InstantCameraAppSrc/CInstantCameraAppSrc.cpp
@@ -57,6 +57,7 @@
 	*/
 
 #include "CInstantCameraAppSrc.h"
+#include <gst/app/gstappsrc.h>
 
 using namespace Pylon;
 using namespace GenApi;
@@ -462,8 +463,7 @@ bool CInstantCameraAppSrc::retrieve_image()
 			NULL);
 
 		// Push the gst buffer wrapping the image buffer to the source pads of the AppSrc element, where it's picked up by the rest of the pipeline
-		GstFlowReturn ret;
-		g_signal_emit_by_name(m_appsrc, "push-buffer", m_gstBuffer, &ret);
+		gst_app_src_push_buffer(GST_APP_SRC(m_appsrc), m_gstBuffer);
 
 		return true;
 	}


### PR DESCRIPTION
I think that there is a memory leak in retrieve_image. After running your project for more than a couple of hours I noticed that the application was eating up gigabytes of ram.

The problem seems to be how you handle the image buffer. I am not an gstreamer expert but I think somebody has to call gst_buffer_unref on this when the buffer is not needed anymore (somewhere after the signal emit).

You could do this by hand but I decided to use the gst_app_src_push_buffer method which takes ownership of the buffer and takes care that the buffer is unrefed implicitly.